### PR TITLE
Fix progress bar maximum rounds

### DIFF
--- a/src/app/game/[gameId]/page.tsx
+++ b/src/app/game/[gameId]/page.tsx
@@ -571,7 +571,11 @@ export default function GamePage() {
         <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4">
           <div className="max-w-6xl mx-auto">
             {/* ゲーム情報 */}
-            <GameInfo gameState={gameState} isConnected={isConnected} />
+            <GameInfo
+              gameState={gameState}
+              isConnected={isConnected}
+              gameType={gameInfo?.gameType || 'HANCHAN'}
+            />
 
             {/* プレイヤー状態 */}
             <PlayerStatus 
@@ -609,7 +613,11 @@ export default function GamePage() {
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-2 sm:p-4">
       <div className="max-w-6xl mx-auto">
         {/* ゲーム情報 */}
-        <GameInfo gameState={gameState} isConnected={isConnected} />
+        <GameInfo
+          gameState={gameState}
+          isConnected={isConnected}
+          gameType={gameInfo?.gameType || 'HANCHAN'}
+        />
 
         {/* プレイヤー状態 */}
         <PlayerStatus 

--- a/src/components/GameInfo.tsx
+++ b/src/components/GameInfo.tsx
@@ -13,9 +13,10 @@ interface GameState {
 interface GameInfoProps {
   gameState: GameState
   isConnected: boolean
+  gameType: 'TONPUU' | 'HANCHAN'
 }
 
-export default function GameInfo({ gameState, isConnected }: GameInfoProps) {
+export default function GameInfo({ gameState, isConnected, gameType }: GameInfoProps) {
   const getRoundName = (round: number) => {
     if (round <= 4) {
       const roundNames = ['東一局', '東二局', '東三局', '東四局']
@@ -59,6 +60,8 @@ export default function GameInfo({ gameState, isConnected }: GameInfoProps) {
       default: return 'bg-gray-100 text-gray-800'
     }
   }
+
+  const maxRound = gameType === 'TONPUU' ? 4 : 8
 
   return (
     <div className="bg-white rounded-lg shadow-lg p-3 sm:p-6 mb-6">
@@ -106,16 +109,16 @@ export default function GameInfo({ gameState, isConnected }: GameInfoProps) {
 
       {/* 進行状況バー */}
       <div className="mb-3 sm:mb-4">
-        <div className="flex justify-between text-xs text-gray-500 mb-1">
-          <span>進行状況</span>
-          <span>{gameState.currentRound}/16局</span>
-        </div>
-        <div className="w-full bg-gray-200 rounded-full h-2">
-          <div 
-            className="bg-blue-600 h-2 rounded-full transition-all duration-300"
-            style={{ width: `${Math.min((gameState.currentRound / 16) * 100, 100)}%` }}
-          />
-        </div>
+      <div className="flex justify-between text-xs text-gray-500 mb-1">
+        <span>進行状況</span>
+          <span>{gameState.currentRound}/{maxRound}局</span>
+      </div>
+      <div className="w-full bg-gray-200 rounded-full h-2">
+        <div
+          className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+          style={{ width: `${Math.min((gameState.currentRound / maxRound) * 100, 100)}%` }}
+        />
+      </div>
       </div>
 
       {/* 詳細情報 */}
@@ -177,7 +180,7 @@ export default function GameInfo({ gameState, isConnected }: GameInfoProps) {
             <div className="flex justify-between">
               <span>オーラス条件</span>
               <span>
-                {gameState.currentRound >= 8 ? 'オーラス圏内' : '通常進行'}
+                {gameState.currentRound >= maxRound ? 'オーラス圏内' : '通常進行'}
               </span>
             </div>
             {gameState.players.some(p => p.points <= 0) && (


### PR DESCRIPTION
## Summary
- adjust GameInfo to accept game type
- show progress based on TONPUU (4 rounds) or HANCHAN (8 rounds)
- pass gameType to GameInfo

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68578171540883278a3582fe877b3f7b