### PR TITLE
Fix game type in GameInfo

### DIFF
--- a/src/app/game/[gameId]/page.tsx
+++ b/src/app/game/[gameId]/page.tsx
@@ -574,7 +574,7 @@ export default function GamePage() {
             <GameInfo
               gameState={gameState}
               isConnected={isConnected}
-              gameType={gameInfo?.gameType || 'HANCHAN'}
+              gameType={gameInfo?.settings?.gameType || 'HANCHAN'}
             />
 
             {/* プレイヤー状態 */}
@@ -588,7 +588,7 @@ export default function GamePage() {
         </div>
         
         <GameEndScreen
-          gameType={gameInfo?.gameType || 'HANCHAN'}
+          gameType={gameInfo?.settings?.gameType || 'HANCHAN'}
           endReason={gameEndReason || '規定局数終了'}
           onShowResult={() => {
             setShowGameEnd(false)
@@ -616,7 +616,7 @@ export default function GamePage() {
         <GameInfo
           gameState={gameState}
           isConnected={isConnected}
-          gameType={gameInfo?.gameType || 'HANCHAN'}
+          gameType={gameInfo?.settings?.gameType || 'HANCHAN'}
         />
 
         {/* プレイヤー状態 */}


### PR DESCRIPTION
## Summary
- get game type from settings
- pass correct game type to GameInfo and GameEndScreen

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_685783edb4808327b5e97783069c5eed