### PR TITLE
Fix hydration mismatch

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="ja">
+    <html lang="ja" data-mantine-color-scheme="light">
       <head>
         <ColorSchemeScript />
       </head>


### PR DESCRIPTION
## Summary
- set `data-mantine-color-scheme` on the `<html>` tag to match Mantine's script

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_685790e65bd083279f2abc7f8a9b42a5