### PR TITLE
Fix host stats refresh

### DIFF
--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -38,11 +38,18 @@ interface PlayerStats {
 
 export default function StatsPage() {
   const router = useRouter()
-  const { user, isAuthenticated } = useAuth()
+  const { user, isAuthenticated, refreshAuth } = useAuth()
   const [stats, setStats] = useState<PlayerStats | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
   const [gameTypeFilter, setGameTypeFilter] = useState<string>('')
+
+  // Ensure auth state is up to date (especially after hosting a game)
+  useEffect(() => {
+    refreshAuth()
+    // intentionally run only once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const fetchStats = async (gameType: string = '') => {
     if (!user) return

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -44,10 +44,15 @@ export default function StatsPage() {
   const [error, setError] = useState('')
   const [gameTypeFilter, setGameTypeFilter] = useState<string>('')
 
-  // Ensure auth state is up to date (especially after hosting a game)
+  // Ensure auth state is loaded (important when hosting a new game)
   useEffect(() => {
-    refreshAuth()
-    // intentionally run only once on mount
+    const ensureAuth = async () => {
+      if (!isAuthenticated) {
+        await refreshAuth()
+      }
+    }
+    // run once on mount
+    void ensureAuth()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 


### PR DESCRIPTION
## Summary
- refresh auth state when loading stats page so hosted players get updated results

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6857938eefb48327af7db9272d536984