### PR TITLE
Fix session listing status filter

### DIFF
--- a/src/__tests__/api/sessions.test.ts
+++ b/src/__tests__/api/sessions.test.ts
@@ -79,6 +79,22 @@ describe('/api/sessions', () => {
         })
       )
     })
+
+    it('ステータスでセッションをフィルタリングできる', async () => {
+      mockPrisma.gameSession.findMany.mockResolvedValue([])
+      mockPrisma.gameSession.count.mockResolvedValue(0)
+
+      const request = new NextRequest('http://localhost:3000/api/sessions?status=ACTIVE')
+      await GET(request)
+
+      expect(mockPrisma.gameSession.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: 'ACTIVE'
+          })
+        })
+      )
+    })
   })
 
   describe('POST', () => {

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -5,11 +5,17 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
     const playerId = searchParams.get('playerId')
+    const status = searchParams.get('status')
     const limit = parseInt(searchParams.get('limit') || '10')
     const offset = parseInt(searchParams.get('offset') || '0')
 
     // 基本的なクエリ条件
     const whereCondition: any = {}
+
+    // ステータスによるフィルタリング
+    if (status) {
+      whereCondition.status = status
+    }
 
     // 特定プレイヤーのセッション履歴の場合
     if (playerId) {


### PR DESCRIPTION
## Summary
- filter sessions by `status` query parameter
- test that GET /api/sessions filters by status

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: TypeError: Cannot set property url of #<NextRequest> which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_685aa7a334708327853356e3d6d59846