### PR TITLE
Fix NextRequest mock for tests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -35,15 +35,14 @@ jest.mock('socket.io-client', () => ({
 // Mock fetch globally
 global.fetch = jest.fn()
 
-// Mock Web APIs for Node.js environment
+// Simple Request/Response mocks for Next.js API routes
 global.Request = class Request {
   constructor(input, init) {
-    this.url = input
     this.method = init?.method || 'GET'
     this.headers = new Map(Object.entries(init?.headers || {}))
     this.body = init?.body
   }
-  
+
   async json() {
     return JSON.parse(this.body || '{}')
   }
@@ -55,7 +54,7 @@ global.Response = class Response {
     this.status = init?.status || 200
     this.headers = new Map(Object.entries(init?.headers || {}))
   }
-  
+
   static json(data, init) {
     return new Response(JSON.stringify(data), {
       ...init,
@@ -65,7 +64,7 @@ global.Response = class Response {
       },
     })
   }
-  
+
   async json() {
     return JSON.parse(this.body)
   }


### PR DESCRIPTION
## Summary
- adjust jest setup to avoid modifying `url` property on `NextRequest`
- keep simple Request/Response mocks for API tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: `socketInstance.off is not a function`, `fireEvent is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_685aaac9b3f48327b8fc592049194e30