### PR TITLE
feat(solo): シングルプレイにウマ設定機能を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -207,6 +207,8 @@ model SoloGame {
   startingOya   Int            @default(0)
   currentOya    Int            @default(0)
   initialPoints Int            @default(25000)
+  basePoints    Int            @default(30000)
+  uma           Json           @default("[15000, 5000, -5000, -15000]")
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
   startedAt     DateTime?

--- a/src/app/api/solo/create/route.ts
+++ b/src/app/api/solo/create/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
       }, { status: 400 })
     }
 
-    const { gameType, initialPoints, players } = validation.data
+    const { gameType, initialPoints, basePoints, uma, players } = validation.data
 
     // プレイヤー名の重複チェック
     if (!validatePlayerNames(players)) {
@@ -66,6 +66,8 @@ export async function POST(request: NextRequest) {
           hostPlayerId,
           gameType,
           initialPoints,
+          basePoints,
+          uma: uma,
           status: 'WAITING'
         }
       })
@@ -115,6 +117,8 @@ export async function POST(request: NextRequest) {
         gameId: result.soloGame.id,
         gameType: result.soloGame.gameType,
         initialPoints: result.soloGame.initialPoints,
+        basePoints: result.soloGame.basePoints,
+        uma: result.soloGame.uma,
         players: result.soloPlayers.map(p => ({
           position: p.position,
           name: p.name,

--- a/src/app/solo/create/page.tsx
+++ b/src/app/solo/create/page.tsx
@@ -10,11 +10,20 @@ import {
   validatePlayerNames,
   validatePlayerPositions
 } from '@/schemas/solo'
+import { DEFAULT_UMA_SETTINGS } from '@/schemas/common'
 
 export default function SoloCreatePage() {
   const router = useRouter()
   const [gameType, setGameType] = useState<'TONPUU' | 'HANCHAN'>(DEFAULT_GAME_TYPE)
   const [initialPoints, setInitialPoints] = useState(DEFAULT_INITIAL_POINTS)
+  const [basePoints, setBasePoints] = useState(30000)
+  const [uma, setUma] = useState<number[]>([
+    DEFAULT_UMA_SETTINGS.first,
+    DEFAULT_UMA_SETTINGS.second,
+    DEFAULT_UMA_SETTINGS.third,
+    DEFAULT_UMA_SETTINGS.fourth
+  ])
+  const [umaPreset, setUmaPreset] = useState('ワンツー')
   const [playerNames, setPlayerNames] = useState([...DEFAULT_PLAYER_NAMES])
   const [isCreating, setIsCreating] = useState(false)
   const [error, setError] = useState('')
@@ -23,6 +32,26 @@ export default function SoloCreatePage() {
     const newNames = [...playerNames]
     newNames[index] = name
     setPlayerNames(newNames)
+  }
+
+  const umaPresets = {
+    'ゴットー': [10, 5, -5, -10],
+    'ワンツー': [20, 10, -10, -20],
+    'ワンスリー': [30, 10, -10, -30]
+  }
+
+  const handleUmaPresetChange = (preset: string) => {
+    setUmaPreset(preset)
+    if (preset !== 'カスタム') {
+      setUma(umaPresets[preset as keyof typeof umaPresets])
+    }
+  }
+
+  const handleUmaChange = (index: number, value: number) => {
+    const newUma = [...uma]
+    newUma[index] = value
+    setUma(newUma)
+    setUmaPreset('カスタム') // 手動変更時はカスタムに切り替え
   }
 
   const handleCreateGame = async () => {
@@ -50,6 +79,8 @@ export default function SoloCreatePage() {
       const gameData: CreateSoloGameInput = {
         gameType,
         initialPoints,
+        basePoints,
+        uma,
         players
       }
 
@@ -138,6 +169,83 @@ export default function SoloCreatePage() {
                 <option value={30000}>30,000点</option>
                 <option value={35000}>35,000点</option>
               </select>
+            </div>
+
+            {/* 返し点 */}
+            <div>
+              <label htmlFor="basePoints" className="block text-sm font-medium text-gray-700 mb-2">
+                返し点（基準点）
+              </label>
+              <select
+                id="basePoints"
+                value={basePoints}
+                onChange={(e) => setBasePoints(Number(e.target.value))}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+              >
+                <option value={25000}>25,000点</option>
+                <option value={30000}>30,000点</option>
+                <option value={35000}>35,000点</option>
+              </select>
+              <p className="text-xs text-gray-500 mt-1">
+                精算計算の基準となる点数
+              </p>
+            </div>
+
+            {/* ウマ設定 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-3">
+                ウマ設定
+              </label>
+              
+              {/* プリセット選択 */}
+              <div className="mb-4">
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                  {Object.keys(umaPresets).map((preset) => (
+                    <button
+                      key={preset}
+                      type="button"
+                      onClick={() => handleUmaPresetChange(preset)}
+                      className={`p-3 rounded-lg border-2 text-sm transition-colors ${
+                        umaPreset === preset
+                          ? 'border-orange-500 bg-orange-50 text-orange-700'
+                          : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300'
+                      }`}
+                    >
+                      <div className="font-semibold">{preset}</div>
+                      <div className="text-xs text-gray-500">
+                        {umaPresets[preset as keyof typeof umaPresets].join(',')}
+                      </div>
+                    </button>
+                  ))}
+                  <button
+                    type="button"
+                    onClick={() => handleUmaPresetChange('カスタム')}
+                    className={`p-3 rounded-lg border-2 text-sm transition-colors ${
+                      umaPreset === 'カスタム'
+                        ? 'border-orange-500 bg-orange-50 text-orange-700'
+                        : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300'
+                    }`}
+                  >
+                    <div className="font-semibold">カスタム</div>
+                    <div className="text-xs text-gray-500">手動設定</div>
+                  </button>
+                </div>
+              </div>
+
+              {/* 詳細設定 */}
+              <div className="grid grid-cols-4 gap-2">
+                {['1位', '2位', '3位', '4位'].map((rank, index) => (
+                  <div key={rank}>
+                    <label className="block text-xs text-gray-500 mb-1">{rank}</label>
+                    <input
+                      type="number"
+                      value={uma[index]}
+                      onChange={(e) => handleUmaChange(index, Number(e.target.value))}
+                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-orange-500"
+                    />
+                  </div>
+                ))}
+              </div>
             </div>
 
             {/* プレイヤー名設定 */}

--- a/src/lib/solo/solo-point-manager.ts
+++ b/src/lib/solo/solo-point-manager.ts
@@ -454,16 +454,16 @@ export class SoloPointManager {
       return
     }
 
-    // デフォルト設定
-    const defaultSettings = {
+    // ゲーム設定を使用（データベースに保存された値）
+    const gameSettings = {
       initialPoints: game.initialPoints,
-      basePoints: 30000,
-      uma: [20, 10, -10, -20]
+      basePoints: game.basePoints || 30000,
+      uma: Array.isArray(game.uma) ? game.uma as number[] : [15000, 5000, -5000, -15000]
     }
     
-    console.log('🏁 Using settings:', defaultSettings)
+    console.log('🏁 Using settings:', gameSettings)
     
-    const finalResults = this.calculateSettlement(players, defaultSettings)
+    const finalResults = this.calculateSettlement(players, gameSettings)
     await this.saveFinalResults(finalResults, players)
   }
 

--- a/src/schemas/__tests__/solo-uma.test.ts
+++ b/src/schemas/__tests__/solo-uma.test.ts
@@ -1,0 +1,78 @@
+import { CreateSoloGameSchema, UmaSettingsSchema } from '../solo'
+
+describe('Solo Uma Settings Schema', () => {
+  describe('UmaSettingsSchema', () => {
+    it('有効なウマ設定を受け入れる', () => {
+      const validUma = [20, 10, -10, -20]
+      const result = UmaSettingsSchema.safeParse(validUma)
+      expect(result.success).toBe(true)
+    })
+
+    it('合計が0でないウマ設定を拒否する', () => {
+      const invalidUma = [20, 10, -10, -15] // 合計が5
+      const gameData = {
+        gameType: 'HANCHAN' as const,
+        initialPoints: 25000,
+        basePoints: 30000,
+        uma: invalidUma,
+        players: [
+          { position: 0, name: '東家' },
+          { position: 1, name: '南家' },
+          { position: 2, name: '西家' },
+          { position: 3, name: '北家' }
+        ]
+      }
+      const result = CreateSoloGameSchema.safeParse(gameData)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('ウマの合計は0である必要があります')
+      }
+    })
+
+    it('デフォルト値を設定する', () => {
+      const result = UmaSettingsSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toEqual([15000, 5000, -5000, -15000])
+      }
+    })
+  })
+
+  describe('CreateSoloGameSchema', () => {
+    it('有効なゲーム作成データを受け入れる', () => {
+      const validData = {
+        gameType: 'HANCHAN' as const,
+        initialPoints: 25000,
+        basePoints: 30000,
+        uma: [20, 10, -10, -20],
+        players: [
+          { position: 0, name: '東家' },
+          { position: 1, name: '南家' },
+          { position: 2, name: '西家' },
+          { position: 3, name: '北家' }
+        ]
+      }
+      const result = CreateSoloGameSchema.safeParse(validData)
+      expect(result.success).toBe(true)
+    })
+
+    it('basePointsのデフォルト値を設定する', () => {
+      const dataWithoutBasePoints = {
+        gameType: 'HANCHAN' as const,
+        initialPoints: 25000,
+        uma: [20, 10, -10, -20],
+        players: [
+          { position: 0, name: '東家' },
+          { position: 1, name: '南家' },
+          { position: 2, name: '西家' },
+          { position: 3, name: '北家' }
+        ]
+      }
+      const result = CreateSoloGameSchema.safeParse(dataWithoutBasePoints)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.basePoints).toBe(30000)
+      }
+    })
+  })
+})

--- a/src/schemas/solo.ts
+++ b/src/schemas/solo.ts
@@ -11,7 +11,8 @@ import {
   validatePlayerPositions,
   DEFAULT_PLAYER_NAMES,
   DEFAULT_INITIAL_POINTS,
-  DEFAULT_GAME_TYPE
+  DEFAULT_GAME_TYPE,
+  DEFAULT_UMA_SETTINGS
 } from './common'
 
 // ===== ソロプレイ専用スキーマ =====
@@ -47,10 +48,21 @@ export const CreateSoloPlayerSchema = z.object({
 })
 export type CreateSoloPlayerInput = z.infer<typeof CreateSoloPlayerSchema>
 
+// ウマ設定スキーマ
+export const UmaSettingsSchema = z.array(z.number().int()).length(4, 'ウマは4つの値が必要です').default([
+  DEFAULT_UMA_SETTINGS.first,
+  DEFAULT_UMA_SETTINGS.second,
+  DEFAULT_UMA_SETTINGS.third,
+  DEFAULT_UMA_SETTINGS.fourth
+])
+export type UmaSettings = z.infer<typeof UmaSettingsSchema>
+
 // ゲーム作成スキーマ
 export const CreateSoloGameSchema = z.object({
   gameType: GameTypeSchema.default(DEFAULT_GAME_TYPE),
   initialPoints: z.number().int().positive().default(DEFAULT_INITIAL_POINTS),
+  basePoints: z.number().int().positive().default(30000),
+  uma: UmaSettingsSchema,
   players: z.array(CreateSoloPlayerSchema).length(4, '4人のプレイヤーが必要です')
 }).refine(
   (data) => validatePlayerNames(data.players.map(p => ({ name: p.name }))),
@@ -63,6 +75,12 @@ export const CreateSoloGameSchema = z.object({
   {
     message: '無効なプレイヤー位置があります',
     path: ['players']
+  }
+).refine(
+  (data) => data.uma.reduce((sum, value) => sum + value, 0) === 0,
+  {
+    message: 'ウマの合計は0である必要があります',
+    path: ['uma']
   }
 )
 export type CreateSoloGameInput = z.infer<typeof CreateSoloGameSchema>


### PR DESCRIPTION
## 概要

シングルプレイモードに、ゲーム開始前のウマ設定機能を追加しました。これにより、マルチプレイと同様の柔軟なルール設定が可能になります。

## 変更内容

- **ウマ設定UIの追加:**
  - ゲーム作成画面（`/solo/create`）に、返し点とウマを設定するフォームを追加しました。
  - 「ゴットー」「ワンツー」「ワンスリー」のプリセットから選択、またはカスタム値を入力できます。
- **APIの機能拡張:**
  - `POST /api/solo/create` エンドポイントで、`basePoints` と `uma` を受け取れるようにしました。
  - Zodスキーマ (`CreateSoloGameSchema`) にバリデーションを追加し、ウマの合計値が0であることを保証します。
- **精算ロジックの更新:**
  - `SoloPointManager` が、データベースに保存されたゲームごとのウマ設定を読み込んで精算処理を行うように修正しました。
- **データベーススキーマの変更:**
  - `SoloGame` モデルに `basePoints` と `uma` カラムを追加しました。

## テスト

- **単体テスト:**
  - `solo-uma.test.ts` を追加し、ウマ設定のバリデーションロジックをテスト済みです。
- **E2Eテスト:**
  - 既存のPlaywrightテストスイートを実行し、すべてのテストがパスすることを確認しました。

## 関連ドキュメント

- `GEMINI.md`
- `@ai-rules/pr-guide.md`