### PR TITLE
fix: APIテストの認証エラーとReact警告を修正

### DIFF
--- a/src/__tests__/api/room-join-session-participant.test.ts
+++ b/src/__tests__/api/room-join-session-participant.test.ts
@@ -47,6 +47,41 @@ jest.mock('@/lib/socket', () => ({
   })),
 }))
 
+// NextRequestとNextResponseのモック
+jest.mock('next/server', () => {
+  return {
+    NextRequest: jest.fn().mockImplementation((url, options) => {
+      let requestBody = {}
+      if (options?.body) {
+        try {
+          requestBody = JSON.parse(options.body)
+        } catch {
+          requestBody = {}
+        }
+      }
+
+      return {
+        url,
+        method: options?.method || 'GET',
+        json: jest.fn(() => Promise.resolve(requestBody)),
+        headers: new Map(),
+      }
+    }),
+    NextResponse: {
+      json: jest.fn((data, options) => {
+        const response = {
+          json: jest.fn(() => Promise.resolve(data)),
+          status: options?.status || 200,
+          cookies: {
+            set: jest.fn(),
+          },
+        }
+        return response
+      }),
+    },
+  }
+})
+
 const mockPrisma = prisma as jest.Mocked<typeof prisma>
 
 describe('ルーム参加時のセッション参加者登録', () => {
@@ -93,15 +128,15 @@ describe('ルーム参加時のセッション参加者登録', () => {
     mockPrisma.game.findUnique.mockResolvedValue({
       ...mockGame,
       participants: [
-        { 
-          playerId: 'host-player', 
-          position: 0, 
-          player: { name: 'ホストプレイヤー' } 
+        {
+          playerId: 'host-player',
+          position: 0,
+          player: { name: 'ホストプレイヤー' }
         },
-        { 
-          playerId: 'test-player-id', 
-          position: 1, 
-          player: { name: 'テストプレイヤー' } 
+        {
+          playerId: 'test-player-id',
+          position: 1,
+          player: { name: 'テストプレイヤー' }
         }
       ]
     } as any)
@@ -150,7 +185,7 @@ describe('ルーム参加時のセッション参加者登録', () => {
 
     expect(response.status).toBe(200)
     expect(data.success).toBe(true)
-    
+
     // GameParticipantが作成されることを確認
     expect(mockTxGameParticipantCreate).toHaveBeenCalledWith({
       data: {
@@ -225,15 +260,15 @@ describe('ルーム参加時のセッション参加者登録', () => {
     mockPrisma.game.findUnique.mockResolvedValue({
       ...mockGame,
       participants: [
-        { 
-          playerId: 'host-player', 
-          position: 0, 
-          player: { name: 'ホストプレイヤー' } 
+        {
+          playerId: 'host-player',
+          position: 0,
+          player: { name: 'ホストプレイヤー' }
         },
-        { 
-          playerId: 'test-player-id', 
-          position: 1, 
-          player: { name: 'テストプレイヤー' } 
+        {
+          playerId: 'test-player-id',
+          position: 1,
+          player: { name: 'テストプレイヤー' }
         }
       ]
     } as any)
@@ -273,7 +308,7 @@ describe('ルーム参加時のセッション参加者登録', () => {
 
     expect(response.status).toBe(200)
     expect(data.success).toBe(true)
-    
+
     // GameParticipantは作成される
     expect(mockTxGameParticipantCreate).toHaveBeenCalled()
 
@@ -315,15 +350,15 @@ describe('ルーム参加時のセッション参加者登録', () => {
     mockPrisma.game.findUnique.mockResolvedValue({
       ...mockGame,
       participants: [
-        { 
-          playerId: 'host-player', 
-          position: 0, 
-          player: { name: 'ホストプレイヤー' } 
+        {
+          playerId: 'host-player',
+          position: 0,
+          player: { name: 'ホストプレイヤー' }
         },
-        { 
-          playerId: 'test-player-id', 
-          position: 1, 
-          player: { name: 'テストプレイヤー' } 
+        {
+          playerId: 'test-player-id',
+          position: 1,
+          player: { name: 'テストプレイヤー' }
         }
       ]
     } as any)
@@ -361,7 +396,7 @@ describe('ルーム参加時のセッション参加者登録', () => {
 
     expect(response.status).toBe(200)
     expect(data.success).toBe(true)
-    
+
     // GameParticipantは作成される
     expect(mockTxGameParticipantCreate).toHaveBeenCalled()
 

--- a/src/__tests__/api/sessions.test.ts
+++ b/src/__tests__/api/sessions.test.ts
@@ -1,5 +1,6 @@
 import { GET, POST } from '@/app/api/sessions/route'
 import { prisma } from '@/lib/prisma'
+import { getCurrentPlayer } from '@/lib/auth'
 import { NextRequest } from 'next/server'
 
 // Prismaのモック
@@ -13,7 +14,11 @@ jest.mock('@/lib/prisma', () => ({
   },
 }))
 
+// 認証のモック
+jest.mock('@/lib/auth')
+
 const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockGetCurrentPlayer = getCurrentPlayer as jest.MockedFunction<typeof getCurrentPlayer>
 
 describe('/api/sessions', () => {
   beforeEach(() => {
@@ -22,6 +27,12 @@ describe('/api/sessions', () => {
 
   describe('GET', () => {
     it('セッション一覧を正常に取得できる', async () => {
+      // 認証モックを設定
+      mockGetCurrentPlayer.mockResolvedValue({
+        playerId: 'player1',
+        name: 'プレイヤー1'
+      })
+
       const mockSessions = [
         {
           id: 'session1',
@@ -61,6 +72,12 @@ describe('/api/sessions', () => {
     })
 
     it('特定プレイヤーのセッション履歴を取得できる', async () => {
+      // 認証モックを設定
+      mockGetCurrentPlayer.mockResolvedValue({
+        playerId: 'player1',
+        name: 'プレイヤー1'
+      })
+
       mockPrisma.gameSession.findMany.mockResolvedValue([])
       mockPrisma.gameSession.count.mockResolvedValue(0)
 
@@ -84,6 +101,12 @@ describe('/api/sessions', () => {
     })
 
     it('ステータスでセッションをフィルタリングできる', async () => {
+      // 認証モックを設定
+      mockGetCurrentPlayer.mockResolvedValue({
+        playerId: 'player1',
+        name: 'プレイヤー1'
+      })
+
       mockPrisma.gameSession.findMany.mockResolvedValue([])
       mockPrisma.gameSession.count.mockResolvedValue(0)
 

--- a/src/components/__tests__/GameResult.test.tsx
+++ b/src/components/__tests__/GameResult.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import GameResult from '../GameResult'
 
 // AuthContextのモック
@@ -40,6 +40,8 @@ const mockSocket = {
 jest.mock('socket.io-client', () => ({
   io: jest.fn(() => mockSocket)
 }))
+
+// タイマーのモック（各テストでセットアップ）
 
 // モックデータ
 const mockGameResultData = {
@@ -106,11 +108,19 @@ describe('GameResult ホスト表示機能', () => {
     })
   })
 
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   test('ホストプレイヤーにホストバッジが表示される', async () => {
-    render(<GameResult gameId="test-game-id" onBack={mockOnBack} />)
+    await act(async () => {
+      render(<GameResult gameId="test-game-id" onBack={mockOnBack} />)
+    })
 
     // APIレスポンスが処理されるまで待機
-    await screen.findByText('対局結果')
+    await waitFor(async () => {
+      await screen.findByText('対局結果')
+    })
 
     // ホストプレイヤー（player1）にホストバッジが表示される
     const hostBadges = screen.getAllByText('👑 ホスト')
@@ -122,10 +132,14 @@ describe('GameResult ホスト表示機能', () => {
   })
 
   test('非ホストプレイヤーにはホストバッジが表示されない', async () => {
-    render(<GameResult gameId="test-game-id" onBack={mockOnBack} />)
+    await act(async () => {
+      render(<GameResult gameId="test-game-id" onBack={mockOnBack} />)
+    })
 
     // APIレスポンスが処理されるまで待機
-    await screen.findByText('対局結果')
+    await waitFor(async () => {
+      await screen.findByText('対局結果')
+    })
 
     // 非ホストプレイヤーの名前の隣にはホストバッジがない
     const player2Elements = screen.getAllByText('テストプレイヤー2')
@@ -155,10 +169,14 @@ describe('GameResult ホスト表示機能', () => {
       })
     })
 
-    render(<GameResult gameId="test-game-id" onBack={mockOnBack} />)
+    await act(async () => {
+      render(<GameResult gameId="test-game-id" onBack={mockOnBack} />)
+    })
 
     // APIレスポンスが処理されるまで待機
-    await screen.findByText('対局結果')
+    await waitFor(async () => {
+      await screen.findByText('対局結果')
+    })
 
     // ホストバッジが表示されていない
     const hostBadges = screen.queryAllByText('👑 ホスト')
@@ -179,10 +197,14 @@ describe('GameResult ホスト表示機能', () => {
       })
     })
 
-    render(<GameResult gameId="test-game-id" onBack={mockOnBack} />)
+    await act(async () => {
+      render(<GameResult gameId="test-game-id" onBack={mockOnBack} />)
+    })
 
     // APIレスポンスが処理されるまで待機
-    await screen.findByText('対局結果')
+    await waitFor(async () => {
+      await screen.findByText('対局結果')
+    })
 
     // ホストバッジが表示される
     const hostBadges = screen.getAllByText('👑 ホスト')


### PR DESCRIPTION
## 概要
テスト実行時に発生していた認証エラーとReact警告を修正し、全てのテストが成功するようにしました。

## 修正内容
- ✅ sessions.test.ts の401認証エラー修正
- ✅ room-join-session-participant.test.ts のNextRequestモック修正  
- ✅ GameResult.test.tsx のReact act()警告修正

## 技術的な変更
- sessions.test.ts: `getCurrentPlayer`モックを追加して認証チェックをパス
- room-join-session-participant.test.ts: NextRequest/NextResponseの適切なモック実装
- GameResult.test.tsx: `act()`と`waitFor`でReactの非同期state更新を適切に処理

## テスト結果
- ✅ **Test Suites: 21 passed, 21 total**
- ✅ **Tests: 139 passed, 139 total**
- ✅ 全ての認証エラーが解消
- ✅ React警告が解消

## 破壊的変更
なし

🤖 Generated with [Claude Code](https://claude.ai/code)