### PR TITLE
Fix prisma mocks in tests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,10 @@
 import "@testing-library/jest-dom"
 
+// Ensure required env vars for Prisma client
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgresql://user:password@localhost:5432/test_db"
+
 // Mock Next.js router
 jest.mock("next/navigation", () => ({
   useRouter() {

--- a/src/lib/__tests__/point-manager.test.ts
+++ b/src/lib/__tests__/point-manager.test.ts
@@ -1,8 +1,6 @@
-import { PointManager } from "../point-manager"
-
-// Mock Prisma
-jest.mock("@/lib/prisma", () => ({
-  prisma: {
+// Prepare Prisma mock before importing the module under test
+jest.mock("@/lib/prisma", () => {
+  const prisma = {
     game: {
       findUnique: jest.fn(),
       update: jest.fn(),
@@ -23,9 +21,12 @@ jest.mock("@/lib/prisma", () => ({
     gameSettings: {
       findFirst: jest.fn(),
     },
-    $transaction: jest.fn((callback) => callback({})),
-  },
-}))
+  }
+  prisma.$transaction = jest.fn(async (callback) => await callback(prisma))
+  return { __esModule: true, prisma, default: prisma }
+})
+
+import { PointManager } from "../point-manager"
 
 // Mock score calculation module
 jest.mock("../score", () => ({

--- a/src/lib/__tests__/score.test.ts
+++ b/src/lib/__tests__/score.test.ts
@@ -1,3 +1,13 @@
+// Prepare Prisma mock before importing the module under test
+jest.mock("@/lib/prisma", () => {
+  const prisma = {
+    scorePattern: {
+      findFirst: jest.fn(),
+    },
+  }
+  return { __esModule: true, prisma, default: prisma }
+})
+
 import {
   calculateScore,
   validateHanFu,
@@ -7,15 +17,6 @@ import {
   ScoreCalculationInput,
   ScorePattern,
 } from "../score"
-
-// Mock Prisma
-jest.mock("@/lib/prisma", () => ({
-  prisma: {
-    scorePattern: {
-      findFirst: jest.fn(),
-    },
-  },
-}))
 
 const mockPrisma = jest.requireMock("@/lib/prisma").prisma
 

--- a/src/lib/__tests__/solo-point-manager.test.ts
+++ b/src/lib/__tests__/solo-point-manager.test.ts
@@ -1,9 +1,6 @@
-import { prisma } from "@/lib/prisma"
-import { SoloPointManager } from "../solo/solo-point-manager"
-
-// Mock Prisma
-jest.mock("@/lib/prisma", () => ({
-  prisma: {
+// Prepare Prisma mock before importing modules
+jest.mock("@/lib/prisma", () => {
+  const prisma = {
     soloGame: {
       findUnique: jest.fn(),
       update: jest.fn(),
@@ -21,9 +18,12 @@ jest.mock("@/lib/prisma", () => ({
     soloGameEvent: {
       create: jest.fn(),
     },
-    $transaction: jest.fn(async (callback) => await callback(prisma)),
-  },
-}))
+  }
+  prisma.$transaction = jest.fn(async (callback) => await callback(prisma))
+  return { __esModule: true, prisma, default: prisma }
+})
+
+import { SoloPointManager } from "../solo/solo-point-manager"
 
 // Mock score calculation module
 jest.mock("../score", () => ({

--- a/src/lib/point-manager.ts
+++ b/src/lib/point-manager.ts
@@ -567,7 +567,7 @@ export class PointManager {
       } else if (typeof game.settings.uma === "string") {
         try {
           umaArray = JSON.parse(game.settings.uma as string)
-        } catch (_e) { // eslint-disable-line @typescript-eslint/no-unused-vars
+        } catch {
           console.log("🏁 Failed to parse uma JSON, using default")
         }
       } else if (typeof game.settings.uma === "object") {

--- a/src/lib/score.ts
+++ b/src/lib/score.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from "@prisma/client"
-
-const prisma = new PrismaClient()
+import prisma from "@/lib/prisma"
 
 export interface ScorePattern {
   oyaPoints: number


### PR DESCRIPTION
## Summary
- ensure Prisma env var during tests
- mock Prisma module correctly with default export
- update score module to reuse shared Prisma client

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- -i` *(fails: 7 failed, 227 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686112fbcca08327aa2db3bd008d97f6