### PR TITLE
fix: update mocks for tests

### DIFF
--- a/src/app/api/players/__tests__/route.test.ts
+++ b/src/app/api/players/__tests__/route.test.ts
@@ -50,7 +50,9 @@ describe("/api/players", () => {
 
       expect(response.status).toBe(200)
       expect(responseData.success).toBe(true)
-      expect(responseData.data).toEqual(mockPlayers)
+      expect(responseData.data).toEqual(
+        mockPlayers.map((p) => ({ ...p, createdAt: p.createdAt.toISOString() }))
+      )
 
       // 作成日時の降順でソートされることを確認
       expect(mockPrisma.player.findMany).toHaveBeenCalledWith({
@@ -70,7 +72,9 @@ describe("/api/players", () => {
     })
 
     it("データベースエラーの処理", async () => {
-      mockPrisma.player.findMany.mockRejectedValue(new Error("DB connection failed"))
+      mockPrisma.player.findMany.mockRejectedValue(
+        new Error("DB connection failed")
+      )
 
       const response = await GET()
       const responseData = await response.json()
@@ -110,7 +114,11 @@ describe("/api/players", () => {
 
       expect(response.status).toBe(201)
       expect(responseData.success).toBe(true)
-      expect(responseData.data).toEqual(mockCreatedPlayer)
+      expect(responseData.data).toEqual({
+        ...mockCreatedPlayer,
+        createdAt: mockCreatedPlayer.createdAt.toISOString(),
+        updatedAt: mockCreatedPlayer.updatedAt.toISOString(),
+      })
 
       expect(mockPrisma.player.create).toHaveBeenCalledWith({
         data: {
@@ -259,7 +267,9 @@ describe("/api/players", () => {
 
     describe("サーバーエラー", () => {
       it("データベース作成エラー", async () => {
-        mockPrisma.player.create.mockRejectedValue(new Error("DB constraint violation"))
+        mockPrisma.player.create.mockRejectedValue(
+          new Error("DB constraint violation")
+        )
 
         const requestBody = {
           name: "Valid Player",

--- a/src/app/api/room/create/__tests__/route.test.ts
+++ b/src/app/api/room/create/__tests__/route.test.ts
@@ -405,7 +405,9 @@ describe("POST /api/room/create", () => {
 
       expect(response.status).toBe(404)
       expect(responseData.success).toBe(false)
-      expect(responseData.error.message).toBe("指定されたセッションが見つかりません")
+      expect(responseData.error.message).toBe(
+        "指定されたセッションが見つかりません"
+      )
     })
   })
 
@@ -526,7 +528,9 @@ describe("POST /api/room/create", () => {
     })
 
     it("データベース接続エラー", async () => {
-      mockPrisma.game.findFirst.mockRejectedValue(new Error("DB connection failed"))
+      mockPrisma.game.findFirst.mockRejectedValue(
+        new Error("DB connection failed")
+      )
 
       const requestBody = {
         hostPlayerName: "Test Player",


### PR DESCRIPTION
## Summary
- share mock instances across test suites
- update player tests for ISO date strings

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: 5 suites, 22 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68611d135ec88327b5b0a9de0fc87250