### PR TITLE
test: expand coverage

### DIFF
--- a/docs/coverage-improvement-plan.md
+++ b/docs/coverage-improvement-plan.md
@@ -1,0 +1,39 @@
+# Test Coverage Improvement Plan
+
+Current overall coverage is around **27%**. To reach 80%+, we will incrementally target the most critical modules first.
+
+## Priorities
+
+1. **Core Business Logic**
+   - Focus on `lib/point-manager.ts`, `lib/solo/solo-point-manager.ts`, and `lib/score.ts`.
+   - Add comprehensive unit tests for score calculations, round progression, and rematch logic.
+
+2. **API Routes with No Coverage**
+   - Cover routes under `app/api/*` starting with game operations (`start`, `cancel-vote-session`, `rematch` etc.).
+   - Use integration tests with mocked Prisma and WebSocket modules.
+
+3. **UI Components**
+   - Begin with frequently used components such as `ScoreInputForm`, `RyukyokuForm`, and `GameInfo`.
+   - Use React Testing Library to assert rendering and user interactions.
+
+4. **Utilities and Hooks**
+   - Test helper utilities in `lib/utils.ts` and custom hooks like `useSocket`.
+   - Ensure error handling via `lib/error-handler.ts` is covered.
+
+## Phase Approach
+
+| Phase | Target Coverage | Focus Areas                     |
+| ----- | --------------- | ------------------------------- |
+| 1     | 50%             | Core business logic & utilities |
+| 2     | 65%             | Remaining API routes            |
+| 3     | 75%             | UI components & contexts        |
+| 4     | 80%+            | Regression tests and edge cases |
+
+Each phase should include updating existing tests, writing new ones, and refactoring for testability when needed.
+
+## Next Steps
+
+1. Create test stubs for the core modules.
+2. Establish mocks for Prisma and Socket.io.
+3. Gradually expand coverage following the priority order above.
+4. Monitor coverage reports on every PR until the 80% goal is met.

--- a/src/lib/__tests__/error-handler.test.ts
+++ b/src/lib/__tests__/error-handler.test.ts
@@ -1,0 +1,82 @@
+import {
+  AppError,
+  ValidationError,
+  createErrorResponse,
+  createSuccessResponse,
+  validateSchema,
+  withErrorHandler,
+  isAppError,
+  isValidationError,
+  getErrorDetails,
+} from "../error-handler"
+import { z } from "zod"
+
+describe("error-handler", () => {
+  test("createErrorResponse handles AppError", async () => {
+    const err = new AppError("TEST", "failed", undefined, 418)
+    const res = createErrorResponse(err)
+    expect(res.status).toBe(418)
+    const data = await res.json()
+    expect(data.success).toBe(false)
+    expect(data.error.code).toBe("TEST")
+  })
+
+  test("createErrorResponse handles ZodError", async () => {
+    const schema = z.object({ name: z.string() })
+    const result = schema.safeParse({})
+    const err = (result as any).error as z.ZodError
+    const res = createErrorResponse(err)
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.error.code).toBe("VALIDATION_ERROR")
+  })
+
+  test("createErrorResponse handles generic Error", async () => {
+    const res = createErrorResponse(new Error("oops"), "default")
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.error.message).toBe("default")
+  })
+
+  test("createSuccessResponse returns success", async () => {
+    const res = createSuccessResponse({ ok: true })
+    const data = await res.json()
+    expect(res.status).toBe(200)
+    expect(data).toEqual({ success: true, data: { ok: true } })
+  })
+
+  test("validateSchema parses valid data", () => {
+    const schema = z.object({ id: z.number() })
+    expect(validateSchema(schema, { id: 1 })).toEqual({ id: 1 })
+    expect(() => validateSchema(schema, {})).toThrow(ValidationError)
+  })
+
+  test("withErrorHandler wraps async functions", async () => {
+    const fn = withErrorHandler(async () => createSuccessResponse("ok"), "fail")
+    const okRes = await fn()
+    expect((await okRes.json()).success).toBe(true)
+
+    const errFn = withErrorHandler(async () => {
+      throw new Error("boom")
+    }, "fail")
+    const errRes = await errFn()
+    expect(errRes.status).toBe(500)
+    const data = await errRes.json()
+    expect(data.error.message).toBe("fail")
+  })
+
+  test("type guards and detail extractor", () => {
+    const appErr = new AppError("X", "x")
+    expect(isAppError(appErr)).toBe(true)
+    expect(isAppError(new Error("x"))).toBe(false)
+
+    const zErr = new z.ZodError([])
+    expect(isValidationError(zErr)).toBe(true)
+    expect(isValidationError(appErr)).toBe(false)
+
+    expect(getErrorDetails(appErr).type).toBe("AppError")
+    expect(getErrorDetails(zErr).type).toBe("ZodError")
+    expect(getErrorDetails(new Error("boom")).type).toBe("Error")
+    expect(getErrorDetails("oops").type).toBe("Unknown")
+  })
+})

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,4 +1,11 @@
-import { getPositionName } from "../utils"
+import {
+  getPositionName,
+  formatPoints,
+  getRoundName,
+  generateRoomCode,
+  calculatePointDifference,
+  cn,
+} from "../utils"
 
 describe("Utils", () => {
   describe("getPositionName", () => {
@@ -77,6 +84,35 @@ describe("Utils", () => {
           expect(wind).toBe(expectedWinds[expectedIndex])
         }
       }
+    })
+  })
+
+  describe("other utility functions", () => {
+    test("formatPoints formats numbers with commas", () => {
+      expect(formatPoints(0)).toBe("0")
+      expect(formatPoints(1234)).toBe("1,234")
+    })
+
+    test("getRoundName returns correct string", () => {
+      expect(getRoundName(1)).toBe("東1局")
+      expect(getRoundName(7)).toBe("南3局")
+    })
+
+    test("generateRoomCode creates four digit codes", () => {
+      const code = generateRoomCode()
+      expect(code).toMatch(/^\d{4}$/)
+      const num = Number(code)
+      expect(num).toBeGreaterThanOrEqual(1000)
+      expect(num).toBeLessThanOrEqual(9999)
+    })
+
+    test("calculatePointDifference computes diff", () => {
+      expect(calculatePointDifference(26000)).toBe(1000)
+      expect(calculatePointDifference(20000, 20000)).toBe(0)
+    })
+
+    test("cn merges class names", () => {
+      expect(cn("a", false && "b", "c")).toBe("a c")
     })
   })
 })


### PR DESCRIPTION
## Summary
- add tests for utility functions like `formatPoints`
- cover error handler helpers with new test suite

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686132a28cc88327b9655200422631ff