### PR TITLE
Add rematch service tests

### DIFF
--- a/docs/coverage-improvement-plan.md
+++ b/docs/coverage-improvement-plan.md
@@ -1,0 +1,52 @@
+# Test Coverage Improvement Plan
+
+The current project-wide coverage is approximately **41%**. Our goal is to reach **80%** or more. Below is the prioritized plan to achieve this.
+
+## 1. Establish Baseline
+
+- Ensure Jest and coverage tools are consistently configured.
+- Add a coverage threshold of 80% in CI to prevent regressions.
+
+## 2. Focus on Core Libraries
+
+Libraries contain business logic that is easy to test without complex setup.
+
+- Add unit tests for files under `lib/` and `lib/solo/` such as `point-manager.ts`, `solo-point-manager.ts`, and `rematch-service.ts`.
+- Cover edge cases in `score.ts`, storage utilities, and vote analysis.
+
+## 3. API Routes
+
+- Write integration tests for API route handlers, starting with those already partially tested:
+  - `app/api/game/[gameId]/result`
+  - `app/api/game/[gameId]/riichi`
+  - `app/api/game/[gameId]/score`
+- Gradually add tests for other routes with complex logic (e.g., `vote-session`, `start`, `rematch`).
+
+## 4. React Components
+
+- Use React Testing Library to test presentational components in `components/`.
+- Prioritize components that contain conditional logic such as `GameResult.tsx`, `ScoreInputForm.tsx`, and `GameInfo.tsx`.
+
+## 5. Hooks and Contexts
+
+- Add unit tests for custom hooks in `hooks/` (e.g., `useSocket.ts`, `usePerformanceMonitor.ts`).
+- Test `AuthContext` behavior for login/logout flows.
+
+## 6. Store and State Management
+
+- Test state transitions in `useAppStore.ts`.
+- Mock dependencies where needed to simulate different game states.
+
+## 7. Schemas and Validation
+
+- Write tests for schema modules to ensure request/response validation works as expected.
+
+## 8. End-to-End Scenarios
+
+- Add Playwright tests to cover common user flows: creating a room, joining, playing a game, and calculating scores.
+
+## 9. Continuous Improvement
+
+- Monitor coverage reports after each test addition.
+- Update documentation when new areas are covered.
+- Revisit untested modules until overall coverage consistently exceeds 80%.

--- a/src/lib/__tests__/rematch-service.test.ts
+++ b/src/lib/__tests__/rematch-service.test.ts
@@ -1,0 +1,95 @@
+import { createRematch } from "../rematch-service"
+
+jest.mock("@/lib/prisma", () => {
+  const prisma = {
+    game: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      count: jest.fn(),
+      create: jest.fn(),
+    },
+    gameSession: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+    sessionParticipant: {
+      create: jest.fn(),
+    },
+    gameParticipant: {
+      create: jest.fn(),
+    },
+  }
+  return { __esModule: true, prisma, default: prisma }
+})
+
+const mockPrisma = jest.requireMock("@/lib/prisma").prisma
+
+describe("createRematch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test("returns error when game is not found", async () => {
+    mockPrisma.game.findUnique.mockResolvedValue(null)
+
+    const result = await createRematch("missing", {})
+
+    expect(result.success).toBe(false)
+    expect(result.error.message).toBe("ゲームが見つかりません")
+  })
+
+  test("returns error when game settings are missing", async () => {
+    mockPrisma.game.findUnique.mockResolvedValue({
+      id: "game1",
+      hostPlayerId: "host",
+      participants: [],
+      session: null,
+      settingsId: null,
+      settings: null,
+    })
+    mockPrisma.game.findFirst.mockResolvedValue(null)
+    mockPrisma.gameSession.findFirst.mockResolvedValue(null)
+    mockPrisma.gameSession.create.mockResolvedValue({
+      id: "s1",
+      sessionCode: "ABC",
+    })
+    mockPrisma.sessionParticipant.create.mockResolvedValue({})
+    mockPrisma.game.create.mockResolvedValue({ id: "g2", roomCode: "ROOM" })
+    mockPrisma.gameParticipant.create.mockResolvedValue({})
+
+    const result = await createRematch("game1", { continueSession: false })
+
+    expect(result.success).toBe(false)
+    expect(result.error.message).toBe("ゲーム設定が見つかりません")
+  })
+
+  test("successfully creates rematch", async () => {
+    mockPrisma.game.findUnique.mockResolvedValue({
+      id: "game1",
+      hostPlayerId: "host",
+      participants: [
+        { playerId: "p1", position: 0 },
+        { playerId: "p2", position: 1 },
+      ],
+      session: null,
+      settingsId: "settings1",
+      settings: { initialPoints: 25000 },
+    })
+    mockPrisma.game.findFirst.mockResolvedValue(null)
+    mockPrisma.gameSession.findFirst.mockResolvedValue(null)
+    mockPrisma.gameSession.create.mockResolvedValue({
+      id: "s1",
+      sessionCode: "ABC",
+    })
+    mockPrisma.sessionParticipant.create.mockResolvedValue({ id: "sp" })
+    mockPrisma.game.create.mockResolvedValue({ id: "g2", roomCode: "ROOM" })
+    mockPrisma.gameParticipant.create.mockResolvedValue({ id: "gp" })
+
+    const result = await createRematch("game1", { continueSession: false })
+
+    expect(result.success).toBe(true)
+    expect(result.data.gameId).toBe("g2")
+    expect(mockPrisma.game.create).toHaveBeenCalled()
+    expect(mockPrisma.gameParticipant.create).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- implement new Jest tests for `createRematch`
- follow the coverage improvement plan

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68615d535da083279fc00b84e887b1ce