### PR TITLE
Add tests for additional API endpoints

### DIFF
--- a/docs/coverage-improvement-plan.md
+++ b/docs/coverage-improvement-plan.md
@@ -1,0 +1,63 @@
+# Test Coverage Improvement Plan
+
+The current project-wide coverage is approximately **42.6%**. Our goal is to reach **80%** or more. Below is the prioritized plan to achieve this.
+
+## 1. Establish Baseline
+
+- Ensure Jest and coverage tools are consistently configured.
+- Add a coverage threshold of 80% in CI to prevent regressions.
+
+## 2. Focus on Core Libraries
+
+Libraries contain business logic that is easy to test without complex setup.
+
+- Add unit tests for files under `lib/` and `lib/solo/` such as `point-manager.ts`, `solo-point-manager.ts`, and `rematch-service.ts`.
+- Cover edge cases in `score.ts`, storage utilities, and vote analysis.
+
+## 3. API Routes
+
+- Write integration tests for API route handlers, starting with those already partially tested:
+  - `app/api/game/[gameId]/result`
+  - `app/api/game/[gameId]/riichi`
+  - `app/api/game/[gameId]/score`
+- Gradually add tests for other routes with complex logic (e.g., `vote-session`, `start`, `rematch`).
+
+## 4. React Components
+
+- Use React Testing Library to test presentational components in `components/`.
+- Prioritize components that contain conditional logic such as `GameResult.tsx`, `ScoreInputForm.tsx`, and `GameInfo.tsx`.
+
+## 5. Hooks and Contexts
+
+- Add unit tests for custom hooks in `hooks/` (e.g., `useSocket.ts`, `usePerformanceMonitor.ts`).
+- Test `AuthContext` behavior for login/logout flows.
+
+## 6. Store and State Management
+
+- Test state transitions in `useAppStore.ts`.
+- Mock dependencies where needed to simulate different game states.
+
+## 7. Schemas and Validation
+
+- Write tests for schema modules to ensure request/response validation works as expected.
+
+## 8. End-to-End Scenarios
+
+- Add Playwright tests to cover common user flows: creating a room, joining, playing a game, and calculating scores.
+
+## 9. Continuous Improvement
+
+- Monitor coverage reports after each test addition.
+- Update documentation when new areas are covered.
+- Revisit untested modules until overall coverage consistently exceeds 80%.
+
+## 10. Target Zero-Coverage Modules
+
+The latest coverage run highlighted several files with **0%** coverage. Prioritize adding tests for these areas to quickly raise overall coverage:
+
+- **API routes**: `admin/migrate-to-sessions`, `auth/logout`, `auth/player`, `game/[gameId]/cancel-vote-session`, `room/[roomCode]/*`, `score/calculate`, `socket`, `solo/[gameId]`, `solo/[gameId]/ryukyoku`, `stats/[playerId]`, and `websocket-status`.
+- **Pages**: top-level pages such as `app/page.tsx`, `app/game/[gameId]/page.tsx`, `app/room/[roomCode]/page.tsx`, `app/sessions/page.tsx`, `app/solo/game/[gameId]/page.tsx`, and `app/stats/page.tsx`.
+- **Components**: utility components including `LazyComponents.tsx`, `OptimizedImage.tsx`, `PointAnimation.tsx`, `QRCodeModal.tsx`, `WebSocketDebug.tsx`, as well as base form components under `components/common` and `components/solo`.
+- **Utilities and helpers**: files like `auth-fallback.ts`, `socket-client.ts`, `socket.ts`, `socketjs.js`, `lib/solo/auth.ts`, and schema files under `schemas/`.
+
+Create small unit tests or integration tests for each of these modules. Even minimal coverage will help raise the overall percentage while ensuring important pathways are validated.

--- a/src/app/api/__tests__/health-route.test.ts
+++ b/src/app/api/__tests__/health-route.test.ts
@@ -1,0 +1,42 @@
+import { GET } from "../health/route"
+import { prisma } from "@/lib/prisma"
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    player: { count: jest.fn() },
+    scorePattern: { count: jest.fn() },
+  },
+}))
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+
+describe("GET /api/health", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("returns healthy status when db calls succeed", async () => {
+    mockPrisma.player.count.mockResolvedValue(5)
+    mockPrisma.scorePattern.count.mockResolvedValue(2)
+
+    const res = await GET()
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.status).toBe("healthy")
+    expect(data.database.players).toBe(5)
+    expect(data.database.scorePatterns).toBe(2)
+  })
+
+  it("returns unhealthy status when db call fails", async () => {
+    mockPrisma.player.count.mockRejectedValue(new Error("db failure"))
+
+    const res = await GET()
+    const data = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(data.status).toBe("unhealthy")
+    expect(data.database.connected).toBe(false)
+    expect(data.database.error).toBe("db failure")
+  })
+})

--- a/src/app/api/__tests__/socket-route.test.ts
+++ b/src/app/api/__tests__/socket-route.test.ts
@@ -1,0 +1,15 @@
+import { GET } from "../socket/route"
+
+describe("GET /api/socket", () => {
+  it("returns status and port", async () => {
+    process.env.SOCKET_IO_PORT = "1234"
+    const res = await GET()
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data).toEqual({
+      status: "WebSocket server ready",
+      port: "1234",
+    })
+  })
+})

--- a/src/app/api/__tests__/websocket-status-route.test.ts
+++ b/src/app/api/__tests__/websocket-status-route.test.ts
@@ -1,0 +1,32 @@
+import { GET } from "../websocket-status/route"
+import { NextRequest } from "next/server"
+
+describe("GET /api/websocket-status", () => {
+  function createRequest() {
+    return new NextRequest("http://localhost", {
+      headers: { host: "localhost", origin: "test", "user-agent": "jest" },
+    })
+  }
+
+  it("reports status when socketio initialized", async () => {
+    ;(process as any).__socketio = {}
+    const res = await GET(createRequest())
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.success).toBe(true)
+    expect(data.status.websocketInitialized).toBe(true)
+    expect(data.message).toMatch(/initialized/)
+  })
+
+  it("reports not found when socketio missing", async () => {
+    ;(process as any).__socketio = undefined
+    const res = await GET(createRequest())
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.success).toBe(true)
+    expect(data.status.websocketInitialized).toBe(false)
+    expect(data.message).toMatch(/not found/)
+  })
+})

--- a/src/app/api/auth/logout/__tests__/route.test.ts
+++ b/src/app/api/auth/logout/__tests__/route.test.ts
@@ -1,0 +1,50 @@
+import { POST } from "../route"
+import { NextRequest } from "next/server"
+import { createMocks } from "node-mocks-http"
+import { cookies } from "next/headers"
+
+const mockSet = jest.fn()
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(() => ({ set: mockSet })),
+}))
+
+describe("POST /api/auth/logout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("clears cookies and returns success", async () => {
+    const { req } = createMocks({ method: "POST" })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(mockSet).toHaveBeenNthCalledWith(1, "session_token", "", {
+      path: "/",
+      httpOnly: true,
+      secure: false,
+      sameSite: "strict",
+      maxAge: 0,
+    })
+    expect(mockSet).toHaveBeenNthCalledWith(2, "player_id", "", {
+      path: "/",
+      httpOnly: true,
+      secure: false,
+      sameSite: "strict",
+      maxAge: 0,
+    })
+  })
+
+  it("returns 500 on failure", async () => {
+    ;(cookies as jest.Mock).mockImplementationOnce(() => {
+      throw new Error("fail")
+    })
+    const { req } = createMocks({ method: "POST" })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error.message).toBe("ログアウトに失敗しました")
+  })
+})

--- a/src/app/api/score/calculate/__tests__/route.test.ts
+++ b/src/app/api/score/calculate/__tests__/route.test.ts
@@ -1,0 +1,81 @@
+import { POST } from "../route"
+import { NextRequest } from "next/server"
+import { createMocks } from "node-mocks-http"
+import * as scoreLib from "@/lib/score"
+
+jest.mock("@/lib/score", () => ({
+  calculateScore: jest.fn(),
+  validateHanFu: jest.fn(),
+}))
+
+describe("POST /api/score/calculate", () => {
+  const { calculateScore, validateHanFu } = scoreLib as jest.Mocked<
+    typeof scoreLib
+  >
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("returns calculation result when valid", async () => {
+    ;(validateHanFu as jest.Mock).mockReturnValue(true)
+    ;(calculateScore as jest.Mock).mockResolvedValue({ result: 8000 })
+    const body = {
+      han: 2,
+      fu: 40,
+      isOya: false,
+      isTsumo: true,
+      honba: 1,
+      kyotaku: 0,
+    }
+    const { req } = createMocks({ method: "POST", json: () => body })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.success).toBe(true)
+    expect(data.data.input).toEqual(body)
+    expect(calculateScore).toHaveBeenCalledWith(body)
+  })
+
+  it("returns 400 when han-fu invalid", async () => {
+    ;(validateHanFu as jest.Mock).mockReturnValue(false)
+    const body = {
+      han: 1,
+      fu: 20,
+      isOya: false,
+      isTsumo: false,
+      honba: 0,
+      kyotaku: 0,
+    }
+    const { req } = createMocks({ method: "POST", json: () => body })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.success).toBe(false)
+  })
+
+  it("returns 400 on validation error", async () => {
+    const { req } = createMocks({ method: "POST", json: () => ({}) })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 500 when calculation fails", async () => {
+    ;(validateHanFu as jest.Mock).mockReturnValue(true)
+    ;(calculateScore as jest.Mock).mockRejectedValue(new Error("fail"))
+    const body = {
+      han: 3,
+      fu: 30,
+      isOya: true,
+      isTsumo: false,
+      honba: 0,
+      kyotaku: 0,
+    }
+    const { req } = createMocks({ method: "POST", json: () => body })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.success).toBe(false)
+    expect(data.error.message).toBe("点数計算に失敗しました")
+  })
+})

--- a/src/app/api/score/patterns/__tests__/route.test.ts
+++ b/src/app/api/score/patterns/__tests__/route.test.ts
@@ -1,0 +1,39 @@
+import { GET } from "../route"
+import { prisma } from "@/lib/prisma"
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    scorePattern: { findMany: jest.fn() },
+  },
+}))
+
+describe("GET /api/score/patterns", () => {
+  const mockPrisma = prisma as jest.Mocked<typeof prisma>
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("returns patterns sorted by han and fu", async () => {
+    mockPrisma.scorePattern.findMany.mockResolvedValue([
+      { han: 1, fu: 30 },
+      { han: 2, fu: 20 },
+    ])
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveLength(2)
+    expect(mockPrisma.scorePattern.findMany).toHaveBeenCalledWith({
+      orderBy: [{ han: "asc" }, { fu: "asc" }],
+    })
+  })
+
+  it("returns 500 on db error", async () => {
+    mockPrisma.scorePattern.findMany.mockRejectedValue(new Error("db"))
+    const res = await GET()
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error.message).toBe("点数パターン取得に失敗しました")
+  })
+})

--- a/src/lib/__tests__/auth-fallback.test.ts
+++ b/src/lib/__tests__/auth-fallback.test.ts
@@ -1,0 +1,80 @@
+import { AuthFallback, fetchWithAuth } from "../auth-fallback"
+
+function createSession() {
+  return { playerId: "p1", sessionToken: "t1", expiresAt: Date.now() + 10000 }
+}
+
+describe("AuthFallback", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    jest.restoreAllMocks()
+  })
+
+  test("setSession and getSession", () => {
+    const session = createSession()
+    AuthFallback.setSession(session)
+    const stored = JSON.parse(localStorage.getItem("mahjong_session")!)
+    expect(stored.playerId).toBe("p1")
+    const result = AuthFallback.getSession()
+    expect(result?.playerId).toBe("p1")
+  })
+
+  test("expired session returns null", () => {
+    const session = {
+      playerId: "p1",
+      sessionToken: "t1",
+      expiresAt: Date.now() - 1000,
+    }
+    AuthFallback.setSession(session)
+    expect(AuthFallback.getSession()).toBeNull()
+  })
+
+  test("clearSession removes data", () => {
+    AuthFallback.setSession(createSession())
+    AuthFallback.clearSession()
+    expect(localStorage.getItem("mahjong_session")).toBeNull()
+  })
+
+  test("isSessionValid reflects session existence", () => {
+    AuthFallback.setSession(createSession())
+    expect(AuthFallback.isSessionValid()).toBe(true)
+    AuthFallback.clearSession()
+    expect(AuthFallback.isSessionValid()).toBe(false)
+  })
+
+  test("getAuthHeaders returns headers when session exists", () => {
+    AuthFallback.setSession(createSession())
+    expect(AuthFallback.getAuthHeaders()).toEqual({
+      "X-Session-Token": "t1",
+      "X-Player-Id": "p1",
+    })
+    AuthFallback.clearSession()
+    expect(AuthFallback.getAuthHeaders()).toEqual({})
+  })
+
+  test("fetchWithAuth adds auth headers", async () => {
+    AuthFallback.setSession(createSession())
+    const fetchSpy = jest.fn().mockResolvedValue(new Response("ok"))
+    global.fetch = fetchSpy as any
+    jest.spyOn(AuthFallback, "getBrowserInfo").mockReturnValue({
+      isSafari: true,
+      isMobile: false,
+      isIOS: false,
+      cookieSupported: false,
+    })
+
+    await fetchWithAuth("https://example.com/api", {
+      method: "GET",
+      headers: { Foo: "bar" },
+    })
+
+    expect(fetchSpy).toHaveBeenCalled()
+    const [, options] = fetchSpy.mock.calls[0]
+    expect(options.headers).toEqual({
+      Foo: "bar",
+      "X-Session-Token": "t1",
+      "X-Player-Id": "p1",
+    })
+    expect(options.credentials).toBe("include")
+  })
+})

--- a/src/lib/__tests__/rematch-service.test.ts
+++ b/src/lib/__tests__/rematch-service.test.ts
@@ -1,0 +1,95 @@
+import { createRematch } from "../rematch-service"
+
+jest.mock("@/lib/prisma", () => {
+  const prisma = {
+    game: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      count: jest.fn(),
+      create: jest.fn(),
+    },
+    gameSession: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+    sessionParticipant: {
+      create: jest.fn(),
+    },
+    gameParticipant: {
+      create: jest.fn(),
+    },
+  }
+  return { __esModule: true, prisma, default: prisma }
+})
+
+const mockPrisma = jest.requireMock("@/lib/prisma").prisma
+
+describe("createRematch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test("returns error when game is not found", async () => {
+    mockPrisma.game.findUnique.mockResolvedValue(null)
+
+    const result = await createRematch("missing", {})
+
+    expect(result.success).toBe(false)
+    expect(result.error.message).toBe("ゲームが見つかりません")
+  })
+
+  test("returns error when game settings are missing", async () => {
+    mockPrisma.game.findUnique.mockResolvedValue({
+      id: "game1",
+      hostPlayerId: "host",
+      participants: [],
+      session: null,
+      settingsId: null,
+      settings: null,
+    })
+    mockPrisma.game.findFirst.mockResolvedValue(null)
+    mockPrisma.gameSession.findFirst.mockResolvedValue(null)
+    mockPrisma.gameSession.create.mockResolvedValue({
+      id: "s1",
+      sessionCode: "ABC",
+    })
+    mockPrisma.sessionParticipant.create.mockResolvedValue({})
+    mockPrisma.game.create.mockResolvedValue({ id: "g2", roomCode: "ROOM" })
+    mockPrisma.gameParticipant.create.mockResolvedValue({})
+
+    const result = await createRematch("game1", { continueSession: false })
+
+    expect(result.success).toBe(false)
+    expect(result.error.message).toBe("ゲーム設定が見つかりません")
+  })
+
+  test("successfully creates rematch", async () => {
+    mockPrisma.game.findUnique.mockResolvedValue({
+      id: "game1",
+      hostPlayerId: "host",
+      participants: [
+        { playerId: "p1", position: 0 },
+        { playerId: "p2", position: 1 },
+      ],
+      session: null,
+      settingsId: "settings1",
+      settings: { initialPoints: 25000 },
+    })
+    mockPrisma.game.findFirst.mockResolvedValue(null)
+    mockPrisma.gameSession.findFirst.mockResolvedValue(null)
+    mockPrisma.gameSession.create.mockResolvedValue({
+      id: "s1",
+      sessionCode: "ABC",
+    })
+    mockPrisma.sessionParticipant.create.mockResolvedValue({ id: "sp" })
+    mockPrisma.game.create.mockResolvedValue({ id: "g2", roomCode: "ROOM" })
+    mockPrisma.gameParticipant.create.mockResolvedValue({ id: "gp" })
+
+    const result = await createRematch("game1", { continueSession: false })
+
+    expect(result.success).toBe(true)
+    expect(result.data.gameId).toBe("g2")
+    expect(mockPrisma.game.create).toHaveBeenCalled()
+    expect(mockPrisma.gameParticipant.create).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/lib/__tests__/socket-client.test.ts
+++ b/src/lib/__tests__/socket-client.test.ts
@@ -1,0 +1,71 @@
+import { socketClient } from "../socket-client"
+import { io as ioClient } from "socket.io-client"
+import { EventEmitter } from "events"
+
+jest.mock("socket.io-client", () => ({
+  io: jest.fn(),
+}))
+
+const mockedIo = ioClient as jest.Mock
+
+function createMockSocket() {
+  const emitter = new EventEmitter() as any
+  emitter.connected = false
+  emitter.emit = jest.fn(emitter.emit.bind(emitter))
+  emitter.on = jest.fn(emitter.on.bind(emitter))
+  emitter.off = jest.fn()
+  emitter.disconnect = jest.fn()
+  emitter.id = "sock1"
+  return emitter
+}
+
+describe("SocketClient", () => {
+  let mockSocket: any
+
+  beforeEach(() => {
+    mockSocket = createMockSocket()
+    mockedIo.mockReturnValue(mockSocket)
+    socketClient.disconnect()
+    jest.clearAllMocks()
+  })
+
+  test("connects using provided url", () => {
+    const socket = socketClient.connect("http://test")
+    expect(socket).toBe(mockSocket)
+    expect(mockedIo).toHaveBeenCalledWith("http://test", expect.any(Object))
+  })
+
+  test("reuses existing connection when already connected", () => {
+    mockSocket.connected = true
+    socketClient.connect("http://first")
+    mockedIo.mockClear()
+    const socket = socketClient.connect("http://second")
+    expect(socket).toBe(mockSocket)
+    expect(mockedIo).not.toHaveBeenCalled()
+  })
+
+  test("disconnect closes socket and clears instance", () => {
+    socketClient.connect("http://test")
+    socketClient.disconnect()
+    expect(mockSocket.disconnect).toHaveBeenCalled()
+    expect(socketClient.getSocket()).toBeNull()
+  })
+
+  test("joinRoom emits correct event", () => {
+    socketClient.connect("http://test")
+    socketClient.joinRoom("ROOM1", "P1")
+    expect(mockSocket.emit).toHaveBeenCalledWith("join_room", {
+      roomCode: "ROOM1",
+      playerId: "P1",
+    })
+  })
+
+  test("on/off game state listener", () => {
+    socketClient.connect("http://test")
+    const cb = jest.fn()
+    socketClient.onGameState(cb)
+    expect(mockSocket.on).toHaveBeenCalledWith("game_state", cb)
+    socketClient.offGameState(cb)
+    expect(mockSocket.off).toHaveBeenCalledWith("game_state", cb)
+  })
+})

--- a/src/lib/__tests__/solo-auth.test.ts
+++ b/src/lib/__tests__/solo-auth.test.ts
@@ -1,0 +1,80 @@
+import { authenticatePlayer, createAuthErrorResponse } from "../solo/auth"
+import { NextRequest } from "next/server"
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    player: { findUnique: jest.fn() },
+  },
+}))
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}))
+
+import { prisma as mockPrisma } from "@/lib/prisma"
+import { cookies as mockCookies } from "next/headers"
+
+function createRequest(headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost", { headers })
+}
+
+describe("authenticatePlayer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test("returns UNAUTHORIZED when no player id", async () => {
+    mockCookies.mockReturnValue({ get: () => undefined })
+
+    const req = createRequest()
+    const result = await authenticatePlayer(req)
+
+    expect(result.success).toBe(false)
+    expect(result.error?.code).toBe("UNAUTHORIZED")
+  })
+
+  test("returns PLAYER_NOT_FOUND when player missing", async () => {
+    mockCookies.mockReturnValue({ get: () => ({ value: "p1" }) })
+    mockPrisma.player.findUnique.mockResolvedValue(null)
+
+    const req = createRequest()
+    const result = await authenticatePlayer(req)
+
+    expect(mockPrisma.player.findUnique).toHaveBeenCalledWith({
+      where: { id: "p1" },
+    })
+    expect(result.success).toBe(false)
+    expect(result.error?.code).toBe("PLAYER_NOT_FOUND")
+  })
+
+  test("returns player info when found via header", async () => {
+    mockCookies.mockReturnValue({ get: () => undefined })
+    const player = {
+      id: "p2",
+      name: "Taro",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+    mockPrisma.player.findUnique.mockResolvedValue(player)
+
+    const req = createRequest({ "x-player-id": "p2" })
+    const result = await authenticatePlayer(req)
+
+    expect(result.success).toBe(true)
+    expect(result.playerId).toBe("p2")
+    expect(result.player).toEqual(player)
+  })
+})
+
+describe("createAuthErrorResponse", () => {
+  test("wraps error", () => {
+    const res = createAuthErrorResponse({
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "ng" },
+    })
+    expect(res).toEqual({
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "ng" },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- cover logout route cookie clearing and failure path
- test score patterns fetch happy and error cases
- validate score calculate route behavior for valid and invalid input

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68615d535da083279fc00b84e887b1ce