### PR TITLE
Add missing unit tests

### DIFF
--- a/src/lib/__tests__/socket-client.test.ts
+++ b/src/lib/__tests__/socket-client.test.ts
@@ -68,4 +68,84 @@ describe("SocketClient", () => {
     socketClient.offGameState(cb)
     expect(mockSocket.off).toHaveBeenCalledWith("game_state", cb)
   })
+
+  test("getSocket returns instance", () => {
+    socketClient.connect("http://test")
+    expect(socketClient.getSocket()).toBe(mockSocket)
+  })
+
+  test("emitters for actions", () => {
+    socketClient.connect("http://test")
+    socketClient.setReady("g1", "p1")
+    socketClient.calculateScore({
+      gameId: "g1",
+      winnerId: "p1",
+      han: 1,
+      fu: 30,
+      isTsumo: true,
+    })
+    socketClient.declareReach("g1", "p1")
+    socketClient.declareRyukyoku("g1", "r", ["p1"])
+    expect(mockSocket.emit).toHaveBeenCalledWith("player_ready", {
+      gameId: "g1",
+      playerId: "p1",
+    })
+    expect(mockSocket.emit).toHaveBeenCalledWith("calculate_score", {
+      gameId: "g1",
+      winnerId: "p1",
+      han: 1,
+      fu: 30,
+      isTsumo: true,
+    })
+    expect(mockSocket.emit).toHaveBeenCalledWith("declare_reach", {
+      gameId: "g1",
+      playerId: "p1",
+    })
+    expect(mockSocket.emit).toHaveBeenCalledWith("ryukyoku", {
+      gameId: "g1",
+      reason: "r",
+      tenpaiPlayers: ["p1"],
+    })
+  })
+
+  test("on/off other listeners", () => {
+    socketClient.connect("http://test")
+    const cb = jest.fn()
+    socketClient.onPlayerJoined(cb)
+    socketClient.onPlayerConnected(cb)
+    socketClient.onGameStart(cb)
+    socketClient.onScoreUpdated(cb)
+    socketClient.onRiichiDeclared(cb)
+    socketClient.onRyukyoku(cb)
+    socketClient.onSeatOrderUpdated(cb)
+    socketClient.onError(cb)
+
+    expect(mockSocket.on).toHaveBeenCalledWith("player_joined", cb)
+    expect(mockSocket.on).toHaveBeenCalledWith("player_connected", cb)
+    expect(mockSocket.on).toHaveBeenCalledWith("game_start", cb)
+    expect(mockSocket.on).toHaveBeenCalledWith("game_started", cb)
+    expect(mockSocket.on).toHaveBeenCalledWith("score_updated", cb)
+    expect(mockSocket.on).toHaveBeenCalledWith("riichi_declared", cb)
+    expect(mockSocket.on).toHaveBeenCalledWith("ryukyoku", cb)
+    expect(mockSocket.on).toHaveBeenCalledWith("seat_order_updated", cb)
+    expect(mockSocket.on).toHaveBeenCalledWith("error", cb)
+
+    socketClient.offPlayerJoined(cb)
+    socketClient.offPlayerConnected(cb)
+    socketClient.offGameStart(cb)
+    socketClient.offScoreUpdated(cb)
+    socketClient.offRiichiDeclared(cb)
+    socketClient.offRyukyoku(cb)
+    socketClient.offSeatOrderUpdated(cb)
+    socketClient.offError(cb)
+    expect(mockSocket.off).toHaveBeenCalledWith("player_joined", cb)
+    expect(mockSocket.off).toHaveBeenCalledWith("player_connected", cb)
+    expect(mockSocket.off).toHaveBeenCalledWith("game_start", cb)
+    expect(mockSocket.off).toHaveBeenCalledWith("game_started", cb)
+    expect(mockSocket.off).toHaveBeenCalledWith("score_updated", cb)
+    expect(mockSocket.off).toHaveBeenCalledWith("riichi_declared", cb)
+    expect(mockSocket.off).toHaveBeenCalledWith("ryukyoku", cb)
+    expect(mockSocket.off).toHaveBeenCalledWith("seat_order_updated", cb)
+    expect(mockSocket.off).toHaveBeenCalledWith("error", cb)
+  })
 })

--- a/src/lib/__tests__/storage-utils.test.ts
+++ b/src/lib/__tests__/storage-utils.test.ts
@@ -55,4 +55,32 @@ describe("storage-utils", () => {
     const size = checkLocalStorageUsage()
     expect(size).toBe(6)
   })
+
+  test("safeSetLocalStorage returns false on generic error", () => {
+    jest.spyOn(localStorage.__proto__, "setItem").mockImplementationOnce(() => {
+      throw new Error("bad")
+    })
+    const ok = safeSetLocalStorage("x", "y")
+    expect(ok).toBe(false)
+  })
+
+  test("checkLocalStorageUsage handles error", () => {
+    const proto = Object.getPrototypeOf(localStorage) as any
+    jest.spyOn(proto, "hasOwnProperty").mockImplementation(() => {
+      throw new Error("fail")
+    })
+    const size = checkLocalStorageUsage()
+    expect(size).toBe(0)
+  })
+
+  test("clearLocalStorageOnQuotaError error path", () => {
+    jest
+      .spyOn(localStorage.__proto__, "removeItem")
+      .mockImplementationOnce(() => {
+        throw new Error("remove fail")
+      })
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    clearLocalStorageOnQuotaError()
+    expect(errSpy).toHaveBeenCalled()
+  })
 })

--- a/src/schemas/__tests__/common-utils.test.ts
+++ b/src/schemas/__tests__/common-utils.test.ts
@@ -1,0 +1,20 @@
+import { validatePlayerPositions, getPlayerPosition } from "../common"
+
+describe("common utils", () => {
+  test("validatePlayerPositions", () => {
+    expect(validatePlayerPositions([0, 1, 2, 3])).toBe(true)
+    expect(validatePlayerPositions([0, 0, 1, 2])).toBe(false)
+    expect(validatePlayerPositions([-1, 1, 2, 3])).toBe(false)
+    expect(validatePlayerPositions([0, 1, 2, 4])).toBe(false)
+  })
+
+  test("getPlayerPosition solo", () => {
+    expect(getPlayerPosition(1, "SOLO")).toBe(1)
+    expect(getPlayerPosition("x", "SOLO")).toBe(0)
+  })
+
+  test("getPlayerPosition multiplayer always 0", () => {
+    expect(getPlayerPosition("abc", "MULTIPLAYER")).toBe(0)
+    expect(getPlayerPosition(2 as any, "MULTIPLAYER")).toBe(0)
+  })
+})

--- a/src/schemas/__tests__/index.test.ts
+++ b/src/schemas/__tests__/index.test.ts
@@ -1,0 +1,84 @@
+import {
+  getScoreCalculationSchema,
+  getRyukyokuSchema,
+  getRiichiSchema,
+  validateScoreCalculation,
+  validateRyukyoku,
+  validateRiichi,
+  isMultiPlayerIdentifier,
+  isSoloPlayerIdentifier,
+  determineGameMode,
+  getSchemaInfo,
+} from "../index"
+import {
+  MultiScoreCalculationSchema,
+  MultiRyukyokuSchema,
+  MultiRiichiSchema,
+} from "../multi"
+import {
+  SoloScoreCalculationSchema,
+  SoloRyukyokuSchema,
+  SoloRiichiSchema,
+} from "../solo"
+
+describe("schemas/index", () => {
+  test("schema getters", () => {
+    expect(getScoreCalculationSchema("MULTIPLAYER")).toBe(
+      MultiScoreCalculationSchema
+    )
+    expect(getScoreCalculationSchema("SOLO")).toBe(SoloScoreCalculationSchema)
+    expect(getRyukyokuSchema("MULTIPLAYER")).toBe(MultiRyukyokuSchema)
+    expect(getRyukyokuSchema("SOLO")).toBe(SoloRyukyokuSchema)
+    expect(getRiichiSchema("MULTIPLAYER")).toBe(MultiRiichiSchema)
+    expect(getRiichiSchema("SOLO")).toBe(SoloRiichiSchema)
+  })
+
+  test("validation helpers", () => {
+    const multiData = {
+      winnerId: "550e8400-e29b-41d4-a716-446655440000",
+      han: 2,
+      fu: 30,
+      isTsumo: false,
+      loserId: "550e8400-e29b-41d4-a716-446655440001",
+    }
+    expect(validateScoreCalculation(multiData, "MULTIPLAYER")).toMatchObject(
+      multiData
+    )
+    const soloData = {
+      winnerId: 0,
+      han: 1,
+      fu: 40,
+      isTsumo: true,
+      isOya: false,
+      isDora: false,
+      isUraDora: false,
+      isAkaDora: false,
+    }
+    const parsedSolo = validateScoreCalculation(soloData, "SOLO")
+    expect(parsedSolo).toMatchObject({
+      winnerId: 0,
+      han: 1,
+      fu: 40,
+      isTsumo: true,
+    })
+    const rData = { reason: "流局", tenpaiPlayers: [] }
+    expect(validateRyukyoku(rData, "SOLO")).toMatchObject(rData)
+    const riichiData = { playerId: "550e8400-e29b-41d4-a716-446655440000" }
+    expect(validateRiichi(riichiData, "MULTIPLAYER")).toEqual(riichiData)
+  })
+
+  test("identifier guards", () => {
+    expect(isMultiPlayerIdentifier("abc")).toBe(true)
+    expect(isMultiPlayerIdentifier(1 as any)).toBe(false)
+    expect(isSoloPlayerIdentifier(2)).toBe(true)
+    expect(isSoloPlayerIdentifier("x" as any)).toBe(false)
+  })
+
+  test("determineGameMode and schema info", () => {
+    expect(determineGameMode({ gameMode: "SOLO" })).toBe("SOLO")
+    expect(determineGameMode({})).toBe("MULTIPLAYER")
+    const info = getSchemaInfo("SOLO")
+    expect(info.gameMode).toBe("SOLO")
+    expect(info.schemaNames).toContain("scoreCalculation")
+  })
+})

--- a/src/schemas/__tests__/multi-utils.test.ts
+++ b/src/schemas/__tests__/multi-utils.test.ts
@@ -1,0 +1,34 @@
+import {
+  validateMultiPlayerId,
+  validateRoomCode,
+  validateSessionVote,
+} from "../multi"
+
+describe("multi utils", () => {
+  test("validateMultiPlayerId", () => {
+    expect(validateMultiPlayerId("550e8400-e29b-41d4-a716-446655440000")).toBe(
+      true
+    )
+    expect(validateMultiPlayerId("invalid")).toBe(false)
+  })
+
+  test("validateRoomCode", () => {
+    expect(validateRoomCode("ABC123")).toBe(true)
+    expect(validateRoomCode("abc123")).toBe(false)
+    expect(validateRoomCode("AAA11")).toBe(false)
+  })
+
+  test("validateSessionVote", () => {
+    const players = ["p1", "p2"]
+    const votes = { p1: "end" }
+    expect(validateSessionVote("p3", votes, players)).toEqual({
+      isValid: false,
+      reason: "プレイヤーがセッションに参加していません",
+    })
+    expect(validateSessionVote("p1", votes, players)).toEqual({
+      isValid: false,
+      reason: "既に投票済みです",
+    })
+    expect(validateSessionVote("p2", votes, players)).toEqual({ isValid: true })
+  })
+})

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -1,5 +1,10 @@
-import { act } from "@testing-library/react"
-import { useAppStore } from "../useAppStore"
+import { renderHook, act } from "@testing-library/react"
+import {
+  useAppStore,
+  useSessionStore,
+  useGameStore,
+  useUIStore,
+} from "../useAppStore"
 
 afterEach(() => {
   act(() => {
@@ -62,4 +67,44 @@ describe("useAppStore", () => {
     expect(state.currentSession).toBeNull()
     expect(state.currentGame).toBeNull()
   })
+})
+
+test("selectors work", () => {
+  const { result: sess } = renderHook(() => useSessionStore())
+  const { result: game } = renderHook(() => useGameStore())
+  const { result: ui } = renderHook(() => useUIStore())
+
+  act(() => {
+    sess.current.setSession({
+      id: "s2",
+      sessionCode: "XYZ",
+      hostPlayerId: "p2",
+      totalGames: 1,
+      createdAt: "2024-01-02",
+      status: "ACTIVE",
+    })
+    sess.current.setSessionMode(true)
+    game.current.setCurrentGame({
+      gameId: "g2",
+      roomCode: "R",
+      status: "WAITING",
+      players: [],
+    })
+    ui.current.setLoading(true)
+    ui.current.setError("e")
+  })
+
+  expect(sess.current.currentSession?.id).toBe("s2")
+  expect(sess.current.sessionMode).toBe(true)
+  expect(game.current.currentGame?.gameId).toBe("g2")
+  expect(ui.current.isLoading).toBe(true)
+  expect(ui.current.error).toBe("e")
+
+  act(() => {
+    sess.current.clearSession()
+    ui.current.clearError()
+  })
+
+  expect(sess.current.currentSession).toBeNull()
+  expect(ui.current.error).toBeNull()
 })


### PR DESCRIPTION
## Summary
- cover remaining SocketClient API endpoints
- improve coverage for storage utilities with error cases
- test Zustand selector hooks
- create tests for unified schema helpers

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68639d955c448327a7327204999d5948