### PR TITLE
Add tests for SessionDetailPage

### DIFF
--- a/src/app/sessions/[sessionId]/__tests__/page.test.tsx
+++ b/src/app/sessions/[sessionId]/__tests__/page.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import SessionDetailPage from "../page"
+
+// Mock react's experimental use to simply return its argument
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  use: (value: any) => value,
+}))
+
+const mockPush = jest.fn()
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+jest.mock("@/components/SessionHistoryTable", () => {
+  return function MockTable({ sessionId }: { sessionId: string }) {
+    return (
+      <div data-testid="history" data-session-id={sessionId}>
+        table
+      </div>
+    )
+  }
+})
+
+describe("SessionDetailPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders heading and passes sessionId", () => {
+    render(<SessionDetailPage params={{ sessionId: "s1" } as any} />)
+
+    expect(screen.getByText("セッション詳細")).toBeInTheDocument()
+    const table = screen.getByTestId("history")
+    expect(table).toHaveAttribute("data-session-id", "s1")
+  })
+
+  it("navigates to sessions list", () => {
+    render(<SessionDetailPage params={{ sessionId: "s2" } as any} />)
+
+    fireEvent.click(screen.getByText("セッション一覧"))
+    expect(mockPush).toHaveBeenCalledWith("/sessions")
+  })
+
+  it("navigates home", () => {
+    render(<SessionDetailPage params={{ sessionId: "s3" } as any} />)
+
+    fireEvent.click(screen.getByText("ホーム"))
+    expect(mockPush).toHaveBeenCalledWith("/")
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for the sessions detail page

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865dce3ce3483278a5ba91f2cb68ada