### PR TITLE
Validate round numbers in utility function

### DIFF
--- a/docs/round-management.md
+++ b/docs/round-management.md
@@ -204,6 +204,7 @@ export class GameEndChecker {
 const RoundDisplay: React.FC<{ roundState: RoundState }> = ({ roundState }) => {
   const getRoundName = (round: number) => {
     const winds = ['東', '南', '西', '北'];
+    if (round < 1 || round > winds.length * 4) return '不明'; // 範囲外の局番号
     const windIndex = Math.floor((round - 1) / 4);
     const roundNumber = ((round - 1) % 4) + 1;
     return `${winds[windIndex]}${roundNumber}局`;

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -98,6 +98,11 @@ describe("Utils", () => {
       expect(getRoundName(7)).toBe("南3局")
     })
 
+    test("getRoundName handles out-of-range values", () => {
+      expect(getRoundName(0)).toBe("不明")
+      expect(getRoundName(17)).toBe("不明")
+    })
+
     test("generateRoomCode creates four digit codes", () => {
       const code = generateRoomCode()
       expect(code).toMatch(/^\d{4}$/)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,6 +11,7 @@ export function formatPoints(points: number): string {
 
 export function getRoundName(round: number): string {
   const winds = ["東", "南", "西", "北"]
+  if (round < 1 || round > winds.length * 4) return "不明"
   const windIndex = Math.floor((round - 1) / 4)
   const roundNumber = ((round - 1) % 4) + 1
   return `${winds[windIndex]}${roundNumber}局`


### PR DESCRIPTION
## Summary
- return "不明" when `getRoundName` receives a round outside 1–16
- test invalid round handling and document the helper

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52a14182883278e2424bb762d6a87