### PR TITLE
test: ユニットテスト追加でカバレッジ向上（E2Eはスキップ）

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const nextJest = require("next/jest")
 
 const createJestConfig = nextJest({
@@ -24,6 +25,8 @@ const customJestConfig = {
   collectCoverageFrom: [
     "src/**/*.{js,jsx,ts,tsx}",
     "!src/**/*.d.ts",
+    // バレル/型定義中心のファイル群はカバレッジ対象外にする
+    "!src/schemas/index.ts",
     "!src/pages/_app.tsx",
     "!src/pages/_document.tsx",
   ],

--- a/src/app/api/websocket-status/__tests__/route.test.ts
+++ b/src/app/api/websocket-status/__tests__/route.test.ts
@@ -1,0 +1,41 @@
+import { GET } from "@/app/api/websocket-status/route"
+import { NextRequest } from "next/server"
+
+declare global {
+  // テスト用: process に __socketio を追加
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace NodeJS {
+    interface Process {
+      __socketio?: object
+    }
+  }
+}
+
+describe("/api/websocket-status GET", () => {
+  test("WebSocket 初期化有無に関わらず成功レスポンスを返す", async () => {
+    // ヘッダー付きの NextRequest を生成
+    const req = new NextRequest("http://localhost/api/websocket-status", {
+      headers: {
+        host: "localhost:3000",
+        origin: "http://localhost:3000",
+        "user-agent": "jest",
+      },
+    })
+
+    // 成功パス（socketio あり）
+    process.__socketio = {}
+    const res1 = await GET(req)
+    const body1 = await res1.json()
+    expect(res1.status).toBe(200)
+    expect(body1.success).toBe(true)
+    expect(body1.status).toBeDefined()
+
+    // 成功パス（socketio なし）
+    delete process.__socketio
+    const res2 = await GET(req)
+    const body2 = await res2.json()
+    expect(res2.status).toBe(200)
+    expect(body2.success).toBe(true)
+    expect(body2.status.websocketInitialized).toBe(false)
+  })
+})

--- a/src/components/__tests__/WebSocketDebug.test.tsx
+++ b/src/components/__tests__/WebSocketDebug.test.tsx
@@ -1,0 +1,146 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import WebSocketDebug, { useWebSocketDebug } from "@/components/WebSocketDebug"
+
+// AuthFallback をモック
+jest.mock("@/lib/auth-fallback", () => ({
+  AuthFallback: {
+    getBrowserInfo: () => ({
+      isSafari: false,
+      isMobile: false,
+      isIOS: false,
+      cookieSupported: true,
+    }),
+    getSession: () => ({
+      playerId: "p1",
+      sessionToken: "tok",
+      expiresAt: Date.now() + 1000,
+    }),
+  },
+}))
+
+describe("WebSocketDebug component", () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch as typeof fetch
+  })
+
+  test("show=false の場合は何も表示しない", () => {
+    const { container } = render(<WebSocketDebug show={false} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  test("show=true で初期フェッチ成功時に情報を表示する", async () => {
+    const mockResponse = {
+      success: true,
+      status: {
+        websocketInitialized: true,
+        environment: "test",
+        timestamp: new Date().toISOString(),
+        socketioVersion: "4.x",
+        serverInfo: {
+          hostname: "localhost",
+          port: "3000",
+          nextauthUrl: "http://localhost:3000",
+        },
+        headers: {
+          host: "localhost:3000",
+          origin: "http://localhost:3000",
+          userAgent: "jest",
+          upgrade: "websocket",
+          connection: "upgrade",
+        },
+      },
+    }
+
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve(mockResponse),
+    }) as unknown as typeof fetch
+
+    render(<WebSocketDebug show={true} />)
+
+    // ステータス情報が描画されるまで待機
+    expect(await screen.findByText(/Environment:/)).toBeInTheDocument()
+    // ボタンの存在（ローディング解除後）
+    expect(screen.getByRole("button", { name: "更新" })).toBeInTheDocument()
+  })
+
+  test("更新ボタンで再フェッチし、エラー表示も行われる", async () => {
+    const successOnce = {
+      success: true,
+      status: {
+        websocketInitialized: false,
+        environment: "test",
+        timestamp: new Date().toISOString(),
+        socketioVersion: "Not Available",
+        serverInfo: {
+          hostname: "localhost",
+          port: "3000",
+          nextauthUrl: undefined,
+        },
+        headers: {
+          host: "localhost:3000",
+          origin: "http://localhost:3000",
+          userAgent: "jest",
+          upgrade: "",
+          connection: "",
+        },
+      },
+    }
+
+    const error = new Error("Network error")
+
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve(successOnce) })
+      .mockRejectedValueOnce(error)
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    render(<WebSocketDebug show={true} />)
+
+    // 初期フェッチが完了してボタンが「更新」に戻るのを待つ
+    await screen.findByRole("button", { name: "更新" })
+    // 更新をクリックするとローディング→エラー表示
+    fireEvent.click(screen.getByRole("button", { name: "更新" }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error:/)).toBeInTheDocument()
+      expect(screen.getByText(/Network error/)).toBeInTheDocument()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("useWebSocketDebug hook", () => {
+  function HookProbe() {
+    const { showDebug } = useWebSocketDebug()
+    return <div data-visible={showDebug ? "1" : "0"}>probe</div>
+  }
+
+  test("Ctrl+Shift+W でトグルする", async () => {
+    render(<HookProbe />)
+    const probe = screen.getByText("probe")
+    // 初期は非表示
+    expect(probe).toHaveAttribute("data-visible", "0")
+
+    // 押下で true
+    const evt = new KeyboardEvent("keydown", {
+      key: "W",
+      ctrlKey: true,
+      shiftKey: true,
+    })
+    window.dispatchEvent(evt)
+    await waitFor(() => expect(probe).toHaveAttribute("data-visible", "1"))
+
+    // もう一度で false
+    window.dispatchEvent(evt)
+    await waitFor(() => expect(probe).toHaveAttribute("data-visible", "0"))
+  })
+})

--- a/src/components/help/__tests__/YakuHelp.test.tsx
+++ b/src/components/help/__tests__/YakuHelp.test.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import YakuHelp from "@/components/help/YakuHelp"
+
+describe("YakuHelp", () => {
+  test("タイトルと子要素が表示される", () => {
+    render(<YakuHelp />)
+    expect(screen.getByText("役・飜数ヘルプ")).toBeInTheDocument()
+    // ルール凡例（バッジの一つを確認）
+    expect(screen.getByText("オープン断么なし")).toBeInTheDocument()
+  })
+})

--- a/src/components/help/__tests__/YakuHelpModal.test.tsx
+++ b/src/components/help/__tests__/YakuHelpModal.test.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import YakuHelpModal from "@/components/help/YakuHelpModal"
+
+describe("YakuHelpModal", () => {
+  test("isOpen=false の場合は表示されない", () => {
+    const { container } = render(
+      <YakuHelpModal isOpen={false} onClose={() => {}} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  test("isOpen=true で開閉ボタンが動作する", () => {
+    const onClose = jest.fn()
+    render(<YakuHelpModal isOpen={true} onClose={onClose} />)
+
+    expect(screen.getByRole("heading", { name: "ヘルプ" })).toBeInTheDocument()
+    const btn = screen.getByRole("button", { name: "ヘルプを閉じる" })
+    fireEvent.click(btn)
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/src/components/tiles/__tests__/TileGroup.test.tsx
+++ b/src/components/tiles/__tests__/TileGroup.test.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import TileGroup from "@/components/tiles/TileGroup"
+
+describe("TileGroup", () => {
+  test("codes の数だけ Tile が並ぶ", () => {
+    const { container } = render(<TileGroup codes={["m1", "p5r", "z7"]} />)
+    // span.inline-flex の直下に Tile コンポーネントが3つ入る
+    const root = container.querySelector("span.inline-flex")
+    expect(root).toBeTruthy()
+    expect(root?.children.length).toBe(3)
+  })
+
+  test("gap と wrap のクラスが適用される", () => {
+    const { container } = render(
+      <TileGroup codes={["m1"]} gap="md" wrap={true} className="extra" />
+    )
+    const root = container.querySelector("span")
+    expect(root).toBeTruthy()
+    expect(root?.className).toContain("gap-2")
+    expect(root?.className).toContain("flex-wrap")
+    expect(root?.className).toContain("extra")
+  })
+})

--- a/src/components/yaku/__tests__/RuleLegend.test.tsx
+++ b/src/components/yaku/__tests__/RuleLegend.test.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { RuleLegend } from "@/components/yaku/RuleLegend"
+
+describe("RuleLegend", () => {
+  test("デフォルトルールでバッジが表示される", () => {
+    render(<RuleLegend />)
+    expect(screen.getByText("オープン断么なし")).toBeInTheDocument()
+    expect(screen.getByText("ダブル役満あり")).toBeInTheDocument()
+    expect(screen.getByText("流し満貫あり")).toBeInTheDocument()
+    expect(screen.getByText("数え役満なし")).toBeInTheDocument()
+  })
+
+  test("ルール指定で条件分岐が反映される", () => {
+    render(
+      <RuleLegend
+        rules={{
+          openTanyao: false,
+          doubleYakuman: false,
+          nagashiMangan: false,
+          kazoeYakuman: false,
+        }}
+      />
+    )
+    expect(screen.getByText("オープン断么なし")).toBeInTheDocument()
+    // 条件付き2つは非表示
+    expect(screen.queryByText("ダブル役満あり")).toBeNull()
+    expect(screen.queryByText("流し満貫あり")).toBeNull()
+    expect(screen.getByText("数え役満なし")).toBeInTheDocument()
+  })
+})

--- a/src/lib/mahjong/__tests__/tile-unicode.test.ts
+++ b/src/lib/mahjong/__tests__/tile-unicode.test.ts
@@ -1,0 +1,16 @@
+import { tileToUnicode } from "@/lib/mahjong/tiles"
+
+describe("tileToUnicode", () => {
+  test("数牌と字牌のUnicodeに変換できる", () => {
+    expect(tileToUnicode("m1")).toMatch(/\p{Extended_Pictographic}/u)
+    expect(tileToUnicode("p9")).toMatch(/\p{Extended_Pictographic}/u)
+    expect(tileToUnicode("s5")).toMatch(/\p{Extended_Pictographic}/u)
+    expect(tileToUnicode("z1")).toBeDefined() // 東
+    expect(tileToUnicode("z7")).toBeDefined() // 中
+  })
+
+  test("不正値はフォールバックを返す", () => {
+    // @ts-expect-error 故意に無効値を渡す
+    expect(tileToUnicode("x1")).toBe("🀫")
+  })
+})


### PR DESCRIPTION
## 概要

E2EがローカルでSIGINT送信まで停止しない状況のため、本PRではE2Eは実行対象外（CIでもスキップ想定）として、未カバー領域のユニットテストを重点追加しました。

## 変更点
- WebSocketDebug の表示・更新・ショートカット操作のテスト追加
- YakuHelp/RuleLegend/YakuHelpModal の表示テスト追加
- TileGroup の基本表示テスト追加
- /api/websocket-status GETハンドラのテスト追加
- 牌のUnicode変換(tileToUnicode)の正常系/異常系テスト追加
- collectCoverageFrom から schemas/index.ts を除外（型/バレル中心のため）

## テスト/QA
- npm run type-check: OK
- npm run lint: OK
- npm run test:coverage: OK（E2E除外）。All tests passed.

## メモ
- さらなる95%超の達成には lib/solo/* および schemas/common.ts の分岐網羅と、APIルートのエッジケース追加が必要です。段階的にフォローアップPRを用意します。
